### PR TITLE
Expose on_restart and on_stopped in Puma::DSL

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -701,6 +701,26 @@ module Puma
       @config.options[:events].on_booted(&block)
     end
 
+    # Code to run when puma is restarting (works for both: single and clustered)
+    #
+    # @example
+    #   on_restart do
+    #     puts 'Before restarting...'
+    #   end
+    def on_restart(&block)
+      @config.options[:events].on_restart(&block)
+    end
+
+    # Code to run after puma is stopped (works for both: single and clustered)
+    #
+    # @example
+    #   on_stopped do
+    #     puts 'After stopping...'
+    #   end
+    def on_stopped(&block)
+      @config.options[:events].on_stopped(&block)
+    end
+
     # When `fork_worker` is enabled, code to run in Worker 0
     # before all other workers are re-forked from this process,
     # after the server has temporarily stopped serving requests


### PR DESCRIPTION

### Description

The `Events` class description says that using `Puma::DSL` it is possible to register callback hooks for each event type, but that was not true.

### Your checklist for this pull request
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have reviewed the [guidelines for contributing](../blob/master/CONTRIBUTING.md) to this repository.
- [ ] I have added (or updated) appropriate tests if this PR fixes a bug or adds a feature.
- [ ] My pull request is 100 lines added/removed or less so that it can be easily reviewed.
- [ ] If this PR doesn't need tests (docs change), I added `[ci skip]` to the title of the PR.
- [ ] If this closes any issues, I have added "Closes `#issue`" to the PR description or my commit messages.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed, including Rubocop.
